### PR TITLE
Increase mobile time clock control button sizes

### DIFF
--- a/client/components/dashboard/user/TimeClockControl.tsx
+++ b/client/components/dashboard/user/TimeClockControl.tsx
@@ -71,10 +71,10 @@ const TimeClockControl = () => {
 
         {/* Clock Out - Mobile */}
         <button className="flex w-[140px] h-[60px] px-5 py-4 justify-center items-center gap-3 rounded-full bg-[#FF6262] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <svg
-              width="12"
-              height="12"
+              width="16"
+              height="16"
               viewBox="0 0 20 21"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"

--- a/client/components/dashboard/user/TimeClockControl.tsx
+++ b/client/components/dashboard/user/TimeClockControl.tsx
@@ -23,10 +23,10 @@ const TimeClockControl = () => {
       <div className="flex md:hidden justify-center items-center gap-6 w-full">
         {/* Clock In - Mobile */}
         <button className="flex w-[140px] h-[60px] px-5 py-4 justify-center items-center gap-3 rounded-full bg-[#4DA64D] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <svg
-              width="12"
-              height="12"
+              width="16"
+              height="16"
               viewBox="0 0 20 21"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
@@ -41,7 +41,7 @@ const TimeClockControl = () => {
                 fill="white"
               />
             </svg>
-            <span className="text-white font-semibold text-xs font-poppins">
+            <span className="text-white font-semibold text-sm font-poppins">
               Clock in
             </span>
           </div>

--- a/client/components/dashboard/user/TimeClockControl.tsx
+++ b/client/components/dashboard/user/TimeClockControl.tsx
@@ -49,10 +49,10 @@ const TimeClockControl = () => {
 
         {/* Break - Mobile */}
         <button className="flex w-[140px] h-[60px] px-5 py-4 justify-center items-center gap-3 rounded-full bg-[#FFA501] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <svg
-              width="12"
-              height="13"
+              width="16"
+              height="17"
               viewBox="0 0 14 15"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"

--- a/client/components/dashboard/user/TimeClockControl.tsx
+++ b/client/components/dashboard/user/TimeClockControl.tsx
@@ -63,7 +63,7 @@ const TimeClockControl = () => {
                 fill="white"
               />
             </svg>
-            <span className="text-white font-semibold text-xs font-poppins">
+            <span className="text-white font-semibold text-sm font-poppins">
               Break
             </span>
           </div>

--- a/client/components/dashboard/user/TimeClockControl.tsx
+++ b/client/components/dashboard/user/TimeClockControl.tsx
@@ -20,7 +20,7 @@ const TimeClockControl = () => {
       {/* Mobile: Horizontal buttons only, Desktop: Full layout with notes */}
 
       {/* Mobile-only: Horizontal buttons without notes */}
-      <div className="flex md:hidden justify-center items-center gap-4 w-full">
+      <div className="flex md:hidden justify-center items-center gap-6 w-full">
         {/* Clock In - Mobile */}
         <button className="flex w-[120px] h-[48px] px-4 py-3 justify-center items-center gap-2 rounded-full bg-[#4DA64D] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
           <div className="flex items-center gap-2">

--- a/client/components/dashboard/user/TimeClockControl.tsx
+++ b/client/components/dashboard/user/TimeClockControl.tsx
@@ -89,7 +89,7 @@ const TimeClockControl = () => {
                 fill="white"
               />
             </svg>
-            <span className="text-white font-semibold text-xs font-poppins">
+            <span className="text-white font-semibold text-sm font-poppins">
               Clock out
             </span>
           </div>

--- a/client/components/dashboard/user/TimeClockControl.tsx
+++ b/client/components/dashboard/user/TimeClockControl.tsx
@@ -22,7 +22,7 @@ const TimeClockControl = () => {
       {/* Mobile-only: Horizontal buttons without notes */}
       <div className="flex md:hidden justify-center items-center gap-6 w-full">
         {/* Clock In - Mobile */}
-        <button className="flex w-[120px] h-[48px] px-4 py-3 justify-center items-center gap-2 rounded-full bg-[#4DA64D] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
+        <button className="flex w-[140px] h-[60px] px-5 py-4 justify-center items-center gap-3 rounded-full bg-[#4DA64D] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
           <div className="flex items-center gap-2">
             <svg
               width="12"

--- a/client/components/dashboard/user/TimeClockControl.tsx
+++ b/client/components/dashboard/user/TimeClockControl.tsx
@@ -70,7 +70,7 @@ const TimeClockControl = () => {
         </button>
 
         {/* Clock Out - Mobile */}
-        <button className="flex w-[120px] h-[48px] px-4 py-3 justify-center items-center gap-2 rounded-full bg-[#FF6262] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
+        <button className="flex w-[140px] h-[60px] px-5 py-4 justify-center items-center gap-3 rounded-full bg-[#FF6262] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
           <div className="flex items-center gap-2">
             <svg
               width="12"

--- a/client/components/dashboard/user/TimeClockControl.tsx
+++ b/client/components/dashboard/user/TimeClockControl.tsx
@@ -48,7 +48,7 @@ const TimeClockControl = () => {
         </button>
 
         {/* Break - Mobile */}
-        <button className="flex w-[120px] h-[48px] px-4 py-3 justify-center items-center gap-2 rounded-full bg-[#FFA501] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
+        <button className="flex w-[140px] h-[60px] px-5 py-4 justify-center items-center gap-3 rounded-full bg-[#FFA501] shadow-[-4px_4px_12px_0_rgba(0,0,0,0.25)] transition-transform hover:scale-105 active:scale-95">
           <div className="flex items-center gap-2">
             <svg
               width="12"


### PR DESCRIPTION
## Purpose
Improve mobile user experience by making the time clock control component more accessible and easier to interact with on mobile devices. The user requested larger buttons with increased font and icon sizes specifically for mobile responsive design.

## Code changes
- Increased mobile button dimensions from 120x48px to 140x60px
- Enlarged button padding from px-4 py-3 to px-5 py-4
- Increased gap spacing between elements from gap-2/gap-4 to gap-3/gap-6
- Scaled up icon sizes from 12x12px to 16x16px (16x17px for break icon)
- Upgraded font size from text-xs to text-sm for better readability
- Applied changes to all three time clock buttons: Clock In, Break, and Clock Out

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b67955e7127d4c049f8d34ce09e64c7e/vibe-field)

👀 [Preview Link](https://b67955e7127d4c049f8d34ce09e64c7e-vibe-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b67955e7127d4c049f8d34ce09e64c7e</projectId>-->
<!--<branchName>vibe-field</branchName>-->